### PR TITLE
Add database seeder with realistic sample data

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -5,12 +5,14 @@ namespace Database\Seeders;
 use App\Models\Policy;
 use App\Models\Signoff;
 use App\Models\User;
-use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
+    use WithoutModelEvents;
+
     public function run(): void
     {
         // Idempotent: clear existing data
@@ -84,17 +86,17 @@ class DatabaseSeeder extends Seeder
             [
                 'policy_id' => $handbook->id,
                 'user_id' => $alice->id,
-                'signed_at' => Carbon::parse('2026-02-10 09:15:00'),
+                'signed_at' => '2026-02-10 09:15:00',
             ],
             [
                 'policy_id' => $handbook->id,
                 'user_id' => $bob->id,
-                'signed_at' => Carbon::parse('2026-02-11 14:32:00'),
+                'signed_at' => '2026-02-11 14:32:00',
             ],
             [
                 'policy_id' => $handbook->id,
                 'user_id' => $charlie->id,
-                'signed_at' => Carbon::parse('2026-02-14 11:08:00'),
+                'signed_at' => '2026-02-14 11:08:00',
             ],
         ]);
 
@@ -103,12 +105,12 @@ class DatabaseSeeder extends Seeder
             [
                 'policy_id' => $hipaa->id,
                 'user_id' => $alice->id,
-                'signed_at' => Carbon::parse('2026-02-12 10:00:00'),
+                'signed_at' => '2026-02-12 10:00:00',
             ],
             [
                 'policy_id' => $hipaa->id,
                 'user_id' => $mike->id,
-                'signed_at' => Carbon::parse('2026-02-13 16:45:00'),
+                'signed_at' => '2026-02-13 16:45:00',
             ],
         ]);
     }


### PR DESCRIPTION
Seeds the database with deterministic sample data that matches the mockup designs, giving the app a realistic populated state for development and demo purposes.

- Six named users (Jane Admin, Mike Manager, Alice Thompson, Bob Martinez, Charlie Kim, Dana Williams) with password `password`
- Four policies with varied due dates: two upcoming, one past-due, one with a file attached
- Sign-offs on the Employee Handbook (Alice, Bob, Charlie signed; Dana and others unsigned) and a couple on HIPAA Training for variety
- Seeder is idempotent — clears existing data before inserting, so `migrate:fresh --seed` is safe to re-run