### PR TITLE
Handle 204 responses in api(), restore session check, add comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CLAUDE.md
 docs/lessons/
+docs/client-guide.md


### PR DESCRIPTION
- api() throws { status, ...body } so callers can inspect the HTTP status
- api() returns undefined as T on 204 instead of calling .json()
- AppRoutes restores GET /user on mount; removes spoofed dev user
- wasLoggedIn converted from useState to useRef to avoid stale closure