### PR TITLE
feat(react): fetch policies from API on Dashboard

### DIFF
--- a/client-react/src/pages/Dashboard.tsx
+++ b/client-react/src/pages/Dashboard.tsx
@@ -30,46 +30,6 @@ export function Dashboard({ user, onLogout }: DashboardProps) {
       .finally(() => setLoading(false));
   }, [navigate]);
 
-  // Mock data
-  // const tableData: PolicyType[] = [
-  //   {
-  //     id: 1,
-  //     title: '2026 Employee Handbook',
-  //     due_date: '2026-03-01',
-  //     created_by: 'Jane Admin',
-  //     has_file: true,
-  //     signed: false,
-  //     overdue: true,
-  //   },
-  //   {
-  //     id: 2,
-  //     title: 'HIPAA Annual Training',
-  //     due_date: '2026-03-15',
-  //     created_by: 'Jane Admin',
-  //     has_file: true,
-  //     signed: false,
-  //     overdue: false,
-  //   },
-  //   {
-  //     id: 3,
-  //     title: 'Workplace Safety Guidelines',
-  //     due_date: '2026-04-30',
-  //     created_by: 'Mike Manager',
-  //     has_file: false,
-  //     signed: false,
-  //     overdue: false,
-  //   },
-  //   {
-  //     id: 4,
-  //     title: 'Remote Work Policy Update',
-  //     due_date: '2026-02-10',
-  //     created_by: 'Jane Admin',
-  //     has_file: false,
-  //     signed: true,
-  //     overdue: false,
-  //   },
-  // ];
-
   // Render NavBar during loading state so that layout doesn't jump
   if (loading) {
     return (


### PR DESCRIPTION
Replaces hardcoded mock data on the Dashboard with a live GET /api/policies call. The mock array was a placeholder from the initial layout work; this wires it up to the real API.

- remove mock tableData array and add useState/useEffect for live data
- rename tableData prop to policies on SummaryStats and PolicyTable
- show a loading state while the fetch is in flight to prevent layout jump
- redirect to /login?expired=1 on 401 to handle session expiry
- drop hardcoded policy count from footer copy