### PR TITLE
feat(seeder): upload real PDFs to MinIO, expand policy spread

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,103 +16,117 @@ class DatabaseSeeder extends Seeder
 
     public function run(): void
     {
-        // Idempotent: clear existing data
         Signoff::query()->delete();
         Policy::query()->delete();
         User::query()->delete();
 
-        // Users
-        $jane = User::create([
-            'name' => 'Jane Admin',
-            'email' => 'jane@example.com',
-            'password' => Hash::make('password'),
-        ]);
-        $mike = User::create([
-            'name' => 'Mike Manager',
-            'email' => 'mike@example.com',
-            'password' => Hash::make('password'),
-        ]);
-        $alice = User::create([
-            'name' => 'Alice Thompson',
-            'email' => 'alice@example.com',
-            'password' => Hash::make('password'),
-        ]);
-        $bob = User::create([
-            'name' => 'Bob Martinez',
-            'email' => 'bob@example.com',
-            'password' => Hash::make('password'),
-        ]);
-        $charlie = User::create([
-            'name' => 'Charlie Kim',
-            'email' => 'charlie@example.com',
-            'password' => Hash::make('password'),
-        ]);
-        $dana = User::create([
-            'name' => 'Dana Williams',
-            'email' => 'dana@example.com',
-            'password' => Hash::make('password'),
-        ]);
+        $jane    = User::create(['name' => 'Jane Admin',     'email' => 'jane@example.com',    'password' => Hash::make('password')]);
+        $mike    = User::create(['name' => 'Mike Manager',   'email' => 'mike@example.com',    'password' => Hash::make('password')]);
+        $alice   = User::create(['name' => 'Alice Thompson', 'email' => 'alice@example.com',   'password' => Hash::make('password')]);
+        $bob     = User::create(['name' => 'Bob Martinez',   'email' => 'bob@example.com',     'password' => Hash::make('password')]);
+        $charlie = User::create(['name' => 'Charlie Kim',    'email' => 'charlie@example.com', 'password' => Hash::make('password')]);
+        $dana    = User::create(['name' => 'Dana Williams',  'email' => 'dana@example.com',    'password' => Hash::make('password')]);
 
-        // Policies
-        $handbook = $jane->policies()->create([
-            'title' => '2026 Employee Handbook',
-            'description' => 'Annual employee handbook covering company policies, benefits, and code of conduct for 2026.',
-            'due_date' => '2026-03-01',
-            'file_path' => 'policies/employee-handbook-2026.pdf',
-            'file_name' => 'employee-handbook-2026.pdf',
-        ]);
-
-        $hipaa = $jane->policies()->create([
-            'title' => 'HIPAA Annual Training',
-            'description' => 'Required annual HIPAA compliance training acknowledgment for all staff with access to protected health information.',
-            'due_date' => '2026-03-15',
-            'file_path' => 'policies/hipaa-training-2026.pdf',
-            'file_name' => 'hipaa-training-2026.pdf',
-        ]);
-
-        $jane->policies()->create([
-            'title' => 'Workplace Safety Guidelines',
-            'description' => 'Updated workplace safety guidelines including emergency procedures, ergonomics standards, and incident reporting protocols.',
-            'due_date' => '2026-04-30',
-        ]);
-
-        $mike->policies()->create([
-            'title' => 'Remote Work Policy Update',
-            'description' => 'Revised remote work policy outlining expectations for home office setup, availability, and communication standards.',
-            'due_date' => '2026-02-10',
-        ]);
-
-        // Sign-offs for Employee Handbook
-        Signoff::insert([
+        // Each entry: creator, policy fields, and an array of [user, signed_at] pairs.
+        // All six users owe sign-offs on every policy — signers here are the ones who have.
+        $policies = [
             [
-                'policy_id' => $handbook->id,
-                'user_id' => $alice->id,
-                'signed_at' => '2026-02-10 09:15:00',
+                'creator'     => $jane,
+                'title'       => '2026 Employee Handbook',
+                'description' => 'Annual employee handbook covering company policies, benefits, code of conduct, and expectations for the 2026 fiscal year. All employees are required to review and acknowledge receipt.',
+                'due_date'    => '2026-01-15',
+                'file_name'   => 'employee-handbook-2026.pdf',
+                'slug'        => 'employee-handbook-2026',
+                'signers'     => [
+                    [$alice,   '2026-01-10 09:15:00'],
+                    [$bob,     '2026-01-12 14:32:00'],
+                    [$charlie, '2026-01-13 11:08:00'],
+                    [$mike,    '2026-01-14 16:20:00'],
+                ],
             ],
             [
-                'policy_id' => $handbook->id,
-                'user_id' => $bob->id,
-                'signed_at' => '2026-02-11 14:32:00',
+                'creator'     => $jane,
+                'title'       => 'HIPAA Annual Training Acknowledgment',
+                'description' => 'Required annual acknowledgment of HIPAA compliance training for all staff with access to protected health information. Failure to complete by the deadline may result in restricted system access.',
+                'due_date'    => '2026-02-01',
+                'file_name'   => 'hipaa-training-2026.pdf',
+                'slug'        => 'hipaa-training-2026',
+                'signers'     => [
+                    [$alice, '2026-01-28 10:00:00'],
+                    [$mike,  '2026-01-30 16:45:00'],
+                ],
             ],
             [
-                'policy_id' => $handbook->id,
-                'user_id' => $charlie->id,
-                'signed_at' => '2026-02-14 11:08:00',
+                'creator'     => $mike,
+                'title'       => 'Remote Work Policy 2026',
+                'description' => 'Revised remote work policy outlining expectations for home office setup, core availability windows, communication standards, and equipment reimbursement procedures.',
+                'due_date'    => '2026-02-28',
+                'file_name'   => 'remote-work-policy-2026.pdf',
+                'slug'        => 'remote-work-policy-2026',
+                'signers'     => [
+                    [$jane,  '2026-02-15 08:30:00'],
+                    [$alice, '2026-02-17 11:45:00'],
+                    [$bob,   '2026-02-18 09:20:00'],
+                ],
             ],
-        ]);
+            [
+                'creator'     => $jane,
+                'title'       => 'Workplace Safety Guidelines',
+                'description' => 'Updated workplace safety guidelines covering emergency procedures, ergonomics standards, incident reporting protocols, and return-to-work procedures following injury or illness.',
+                'due_date'    => '2026-03-15',
+                'file_name'   => 'workplace-safety-guidelines.pdf',
+                'slug'        => 'workplace-safety-guidelines',
+                'signers'     => [
+                    [$jane,  '2026-02-20 09:00:00'],
+                    [$alice, '2026-02-21 14:15:00'],
+                    [$bob,   '2026-02-21 15:30:00'],
+                    [$mike,  '2026-02-22 10:45:00'],
+                ],
+            ],
+            [
+                'creator'     => $mike,
+                'title'       => 'Code of Conduct Refresh',
+                'description' => 'Updated code of conduct reflecting organizational values, conflict resolution procedures, anti-harassment commitments, and revised social media guidelines effective Q2 2026.',
+                'due_date'    => '2026-04-30',
+                'file_name'   => 'code-of-conduct-2026.pdf',
+                'slug'        => 'code-of-conduct-2026',
+                'signers'     => [
+                    [$jane, '2026-02-22 13:00:00'],
+                ],
+            ],
+            [
+                'creator'     => $jane,
+                'title'       => 'IT Acceptable Use Policy',
+                'description' => 'Acceptable use policy for all company systems, devices, and networks. Covers software installation, data classification, password requirements, and security incident reporting.',
+                'due_date'    => '2026-06-30',
+                'file_name'   => 'it-acceptable-use-policy.pdf',
+                'slug'        => 'it-acceptable-use-policy',
+                'signers'     => [],
+            ],
+        ];
 
-        // A few sign-offs for HIPAA too, for variety
-        Signoff::insert([
-            [
-                'policy_id' => $hipaa->id,
-                'user_id' => $alice->id,
-                'signed_at' => '2026-02-12 10:00:00',
-            ],
-            [
-                'policy_id' => $hipaa->id,
-                'user_id' => $mike->id,
-                'signed_at' => '2026-02-13 16:45:00',
-            ],
-        ]);
+        foreach ($policies as $data) {
+            $key     = 'policies/' . $data['slug'] . '.pdf';
+            $content = file_get_contents(database_path('seeders/files/' . $data['slug'] . '.pdf'));
+
+            Storage::disk('s3')->put($key, $content, ['mimetype' => 'application/pdf']);
+
+            $policy = $data['creator']->policies()->create([
+                'title'       => $data['title'],
+                'description' => $data['description'],
+                'due_date'    => $data['due_date'],
+                'file_path'   => $key,
+                'file_name'   => $data['file_name'],
+            ]);
+
+            foreach ($data['signers'] as [$user, $signedAt]) {
+                Signoff::create([
+                    'policy_id' => $policy->id,
+                    'user_id'   => $user->id,
+                    'signed_at' => $signedAt,
+                ]);
+            }
+        }
     }
+
 }

--- a/api/database/seeders/files/code-of-conduct-2026.pdf
+++ b/api/database/seeders/files/code-of-conduct-2026.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260223064344+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260223064344+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 377
+>>
+stream
+GasJLb>,r/&4Q?hMRtDF8fWOCh,;(H%4HUSYpZMJ@L#+I_:N1d:l1'-NFgeSo=/EMaqu\e@Kc+&gcR9p$>g#K05IqU\8R<"K$B_L#4%^0RqC-fMC=]lY^I+!fqD\&*+Q#VX@]Oo.Q(CGN?jl$>GGa@*m`>=Ek;^dDeLfQTViXALIE$04R>UBD9@KQap4Dq7&D^qI2dI",kiQ-Aj^#cA>pM=Gboa(gN0J\\Q;8l!II!5E`X]r)cTRTAdCuIA;q]LCsok[5<'%R]t3'?bFKSDqcGq?b,;.Arl;[_4j@55B:5ebOkZFILkim%M(DuD;Z](+duu,JfAXhs80^I0gDLAjHQ(+mrt,^#8>bcJ_+r"4K@.TW0arpmCrE&r~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000887 00000 n 
+0000000946 00000 n 
+trailer
+<<
+/ID 
+[<6e6b8db00e40f91789cf6056de32bac0><6e6b8db00e40f91789cf6056de32bac0>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1413
+%%EOF

--- a/api/database/seeders/files/employee-handbook-2026.pdf
+++ b/api/database/seeders/files/employee-handbook-2026.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260223064344+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260223064344+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 380
+>>
+stream
+GasJL5u,<O&4Q=R`EsB[Q.QF\\cf!g"WO7B^i_!'+gFc.<93aH6<]5'K#Y+:)ZQ6*/<Fn.C"Fs+=Q&U=5Y)S(7(167]O4ed+,Q@lDK9PKZ-)ZTc3c2";k^6*er"N1(:N!j6KDW,.E=mcRE@C1X`)u[KP+l>]lWX$.,IeUNcSMeIa2C9Eh7DN>&Vl2l'`&9qd?4A6MgEG?u<(cd)jC<Foq&ke/;J3dX#I0Gh3dL-nMVN99k@(BibpP`MY;7*LC1,M.&]BSodrZ3#b])%e2fO\184L%in2`X1sbJpXbN`q(K&OQ+/f@!+$#+pXEWTK$dDCF>\,^.T2*o+ej(iDop#@HV$_BS=f3XM*P%#^Z54:]0HDB2T$gLOtW/>T%X~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000887 00000 n 
+0000000946 00000 n 
+trailer
+<<
+/ID 
+[<2f0f527a80b26bac2ce7725de052a1ff><2f0f527a80b26bac2ce7725de052a1ff>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1416
+%%EOF

--- a/api/database/seeders/files/hipaa-training-2026.pdf
+++ b/api/database/seeders/files/hipaa-training-2026.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260223064344+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260223064344+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 382
+>>
+stream
+GasJL>u/?\'Sc)R/)JJ6`@Rg&h.9;;RWtN\5CiC56Rd+B?2XHFmN^EE1_::?GgCXV)"P&dFK,h\'=`<q?lYmA/*7#R1[[]?ak6USZGa%Vo<MVd.?Ou5<:FajZL$3r"hW9AK9]pscGrD\a/>9(6=oO,%>:)%C>5I\T@RigeSRf7?9rs(>`VfjdlO%iOSF:q=_Y.`O/5KGCep<!o1<mkogYE:H`A65@.JsUY/--&\ZRkp>"+5Pp;VAK@h>AN)JjP$VmrH4&Db05epA3)`AD!td\J8EVHbLDG'<kOn)F&HDo)JHjhL)<[15`3+q-V[]ZZr_j:GTiQFn1t,DCs-WF>XS;6m&P19R8;dae[lp%SRdi-Q7g^fg8W/q`KqBUY`M~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000887 00000 n 
+0000000946 00000 n 
+trailer
+<<
+/ID 
+[<98860c1f22bd787317c9fcd2d15dcb69><98860c1f22bd787317c9fcd2d15dcb69>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1418
+%%EOF

--- a/api/database/seeders/files/it-acceptable-use-policy.pdf
+++ b/api/database/seeders/files/it-acceptable-use-policy.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260223064344+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260223064344+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 336
+>>
+stream
+Gat=c5tf-M&;BTO(%8(F[0a6FNsZ5G#DMpTZKZ2-VFbT%V>oCdG?K#r4Y.8`KU6uU4b82X/@Xkp4,'^?!?n-p&7o074lK^YT:+@1>h)rA,-U=%RO;2c(1Cl4SeZT6*phQP6I`?,PdAcjUVa,f'Tud,_J:DZHeXtQ*9nR0@c$aoolh?baPF9lWK;Jk(l6t!E2I*dZj$7o0eu1".'W4D['_U%&)'a6;bY]]9/Q:k)<+,t#*.-@+$O05+*CR`a/H')njI6cej])ULh!(YCE5J=4XT'LUHp8BO=2G4hMaV.Zm9+*Z9Bi.R6M<ASSJhW+o"S?hV%-I%'gu'`f$G~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000887 00000 n 
+0000000946 00000 n 
+trailer
+<<
+/ID 
+[<f1404643d2f846a4cd026143de211e90><f1404643d2f846a4cd026143de211e90>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1372
+%%EOF

--- a/api/database/seeders/files/remote-work-policy-2026.pdf
+++ b/api/database/seeders/files/remote-work-policy-2026.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260223064344+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260223064344+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 416
+>>
+stream
+GasJL92EGZ&;9NJ'ltq).^<"-oSNc!%Y,aCG+D?C8A(oD/cGE'ksM2>+Bt/6p!/"B!dRsY3->TkPdl&Q&/&O`0qD!853&ol2OQQ(S/7Pg`M=mt7I!EtHmlL)Q?pMQ/iC(/8jX6*Pa&l.k`&aUKQhU3Gi?[+4_-0X2^gmehY)S.e+u'U;97e%MpcF(T1dcq`"=8?ap1]iOKJ%P_&\&L4]$>&iYWSDNEq+L3mp:t_q(SpLGcODY%sd=SjMe`d-M$QX%]:SVD2M?SZrpur:jf;Uq(?;20ogc&'@qq<ITmK!H"Rq>-]<FR!'@<Vr?/del5(.Ie$Q$Zhs(Q9]a%RaBuh6f>]%P"WogH==S5G<"-D`92:0T>Tb+bZ&Sp'+&57/CA?_`GNOa^5/f.cN]hZlD>'<.OF74H\$?Y~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000887 00000 n 
+0000000946 00000 n 
+trailer
+<<
+/ID 
+[<57138e160f718093b41aeff4ae8855ce><57138e160f718093b41aeff4ae8855ce>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1452
+%%EOF

--- a/api/database/seeders/files/workplace-safety-guidelines.pdf
+++ b/api/database/seeders/files/workplace-safety-guidelines.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260223064344+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260223064344+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 379
+>>
+stream
+GasJL5u5BP%#+0K(%4*n)GO2>mYV-P\0-A_LVtcu2CV3Y["".kNClkQPUK/jq"]=RaE`X,1`^P;E-WrV,ZFqE/.8D'go0Qa'8N4G''hk8bApO%"Xiji&aG<j`@T&`*D8t[Eg2`-'O!WrnD:Y.&0>s_Bns<oZ.([liYg5beG7b`J_/5&lpMm5*i2o,Hqp7'+qA4P/"a?FAtF=L'3T_.VW-H34e%&n>7-@j5okZJSCsSHhN/`Z`=$Y/45VnB+su]Y%[Nl;q5.:OcEN[/#h8a57O]*DhY8u]s'f;?SRsM8^Wc7MAG+YEnCEC_:B<+02?nIuT%PMcj%'jtX>`L*g9,gRV(K*hTAIeH87X*0+nRthPe:dUa"YTK!#]CEd/~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000887 00000 n 
+0000000946 00000 n 
+trailer
+<<
+/ID 
+[<c79dd3d91d5bda61082787e674d617ae><c79dd3d91d5bda61082787e674d617ae>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1415
+%%EOF


### PR DESCRIPTION
- replace hardcoded file_path strings with Storage::disk('s3')->put() so objects exist before the DB record is created
- add six per-policy PDF seed files sourced from seeders/files/
- expand from 4 to 6 policies with varied due dates: two past-due, one this week, one in three weeks, two future
- vary sign-off counts (0-4 of 6 signed) to populate all dashboard status states
- refactor policy data into a flat array iterated in a single loop